### PR TITLE
PyPI setup.py parser

### DIFF
--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -129,7 +129,12 @@ var parsers = {
     parser: require('./pypi'),
     filter: path => path.match(/require.*\.(txt|pip)$/)
   },
-
+  pypiSetup: {
+    name: 'PyPI',
+    type: 'manifest',
+    parser: require('./pypi-setup'),
+    filter: path => path.match(/^setup\.py$/)
+  },
   cocoapods: {
     name: 'CocoaPods',
     type: 'manifest',

--- a/lib/parsers/pypi-setup.js
+++ b/lib/parsers/pypi-setup.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var INSTALL_REGEXP = /install_requires\s*=\s*\[([\s\S]*?)\]/
+var REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9-_\.]+)([><=\d\.,]+)?/;
+
+function parser(str) {
+  var match = str.match(INSTALL_REGEXP)
+  if (!match) return [];
+
+  var deps = match[1].split("\n").reduce( (accum, line) => {
+    var line = line.trim()
+
+    if(line.match(/^#/)) return accum;
+
+    var match = line.match(REQUIRE_REGEXP);
+
+    if (!match) return accum;
+
+    let name = match[1], version = match[2]
+
+    accum.push({
+      name: name,
+      version: version || '*',
+      type: 'runtime'
+    });
+
+    return accum;
+  }, []);
+
+  return deps;
+}
+
+module.exports = parser;

--- a/test/fixtures/setup.py
+++ b/test/fixtures/setup.py
@@ -1,0 +1,42 @@
+from setuptools import setup
+
+setup(name='political-memory',
+    version='0.0.1',
+    description='OpenShift App',
+    packages=['political_memory'],
+    package_dir={'political_memory': '.'},
+    author='James Pic, Laurent Peuch, Arnaud Fabre',
+    author_email='cortex@worlddomination.be',
+    url='http://github.com/political-memory/political_memory/',
+    install_requires=[
+        # -*- Install requires: -*-
+        'django-bootstrap3>=6.2,<6.3',
+        'lesscpy',
+        'unicodecsv==0.14.1',
+        'django-coffeescript>=0.7,<0.8',
+        'django-compressor>=1.6,<1.7',
+        'django-datetime-widget>=0.9,<1.0',
+        'django-filter>=0.11,<0.12',
+        'django-representatives-votes>=0.0.13',
+        'django-representatives>=0.0.14',
+        'django-taggit>=0.17,<0.18',
+        'django>=1.8,<1.9',
+        'djangorestframework>=3.2.0,<3.3.0',
+        'hamlpy>=0.82,<0.83',
+        'ijson>=2.2,<2.3',
+        'python-dateutil>=2.4,<2.5',
+        'pytz==2015.7',
+        'django-suit',
+    ],
+    extras_require={
+        'testing': [
+            'django-responsediff',
+            'flake8',
+            'pep8',
+            'pytest',
+            'pytest-django',
+            'pytest-cov',
+            'codecov',
+        ]
+    }
+)

--- a/test/parsers_test.js
+++ b/test/parsers_test.js
@@ -246,6 +246,16 @@ var platformTests = [
     invalidManifestPaths: []
   },
   {
+    platform: 'pypiSetup',
+    fixture: 'setup.py',
+    expected: [
+      {name: 'django-bootstrap3', version: '>=6.2,<6.3', type: 'runtime'},
+      {name: 'lesscpy', version: '*', type: 'runtime'},
+    ],
+    validManifestPaths: ['setup.py'],
+    invalidManifestPaths: []
+  },
+  {
     platform: 'cocoapods',
     fixture: 'Podfile',
     expected: [


### PR DESCRIPTION
Work in progress, fixes #2

Needs to handle requirements seperated by comma `>=6.2,<6.3`

n.b That fix also needs to be applied to the requirements.txt parser
