### PR TITLE
Avoid DependencyCI reporting incorrect results for non-Cargo crates

### DIFF
--- a/lib/parsers/cargo-lock.js
+++ b/lib/parsers/cargo-lock.js
@@ -11,6 +11,10 @@ function parser(str) {
   var deps = [];
   var runtimeDeps = toml.package || [];
   Object.keys(runtimeDeps).forEach( (dep) => {
+    // Only treat packages from crates.io as meaningful dependencies.
+    if (!('source' in runtimeDeps[dep]) || !runtimeDeps[dep].source.startsWith('registry+')) {
+      return;
+    }
     deps.push({
       name: runtimeDeps[dep].name,
       version: runtimeDeps[dep].version,

--- a/lib/parsers/cargo.js
+++ b/lib/parsers/cargo.js
@@ -12,9 +12,16 @@ function parser(str) {
   var runtimeDeps = toml.dependencies || [];
 
   Object.keys(runtimeDeps).forEach( (dep) => {
+    var version = runtimeDeps[dep];
+    if (typeof version === 'object') {
+      if (!('version' in version)) {
+        return;
+      }
+      version = version['version'];
+    }
     deps.push({
       name: dep,
-      version: runtimeDeps[dep],
+      version: version,
       type: 'runtime'
     });
   });

--- a/test/fixtures/Cargo.lock
+++ b/test/fixtures/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashindexed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "local_crate 0.1.0",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,6 +14,19 @@ dependencies = [
  "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "aaa-local-crate"
+version = "0.1.0"
+dependencies = [
+ "aaa-local-crate-depdendency 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aaa-local-crate-dependency"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 
 [[package]]
 name = "advapi32-sys"

--- a/test/fixtures/Cargo.toml
+++ b/test/fixtures/Cargo.toml
@@ -8,4 +8,5 @@ authors = ["Jorge Aparicio <japaricious@gmail.com>",
 [dependencies]
 
 rustc-serialize = "*"
-regex = "*"
+regex = {version = "*", features = ["feature"]}
+local_crate = {path = "../local_crate"}

--- a/test/parsers_test.js
+++ b/test/parsers_test.js
@@ -163,7 +163,11 @@ var platformTests = [
     platform: 'cargo',
     fixture: 'Cargo.toml',
     expected: [
-      {name: "rustc-serialize", version: "*", type: 'runtime'}
+      {name: "rustc-serialize", version: "*", type: 'runtime'},
+      {name: "regex", version: "*", type: 'runtime'}
+    ],
+    unexpected: [
+      "local_crate"
     ],
     validManifestPaths: ['Cargo.toml'],
     invalidManifestPaths: []
@@ -172,7 +176,11 @@ var platformTests = [
     platform: 'cargolockfile',
     fixture: 'Cargo.lock',
     expected: [
+      {name: "aaa-local-crate-dependency", version: "0.17.1", type: 'runtime'},
       {name: "advapi32-sys", version: "0.1.2", type: 'runtime'}
+    ],
+    unexpected: [
+      "aaa-local-crate"
     ],
     validManifestPaths: ['Cargo.lock'],
     invalidManifestPaths: []
@@ -524,6 +532,13 @@ describe('Parser', function(){
         test.expected.forEach(function(pkg, i) {
           assert.deepEqual(packages[i], pkg);
         });
+        if ('unexpected' in test) {
+          test.unexpected.forEach(function(unexpected) {
+            packages.forEach(function(pkg) {
+              assert.notEqual(pkg.name, unexpected);
+            });
+          });
+        }
       })
       .then(done)
       .catch(done);


### PR DESCRIPTION
This should address https://github.com/dependencyci/support/issues/30.